### PR TITLE
fix ambiguous field sql errors

### DIFF
--- a/src/Model/Filter/AbstractFilter.php
+++ b/src/Model/Filter/AbstractFilter.php
@@ -64,6 +64,10 @@ abstract class AbstractFilter
     {
         if ($this->_applicable($data)) {
             $field = $this->config('field');
+            // avoid sql ambiguous field error
+            if (strpos($field, '.') === false) {
+                $field = $query->repository()->alias() . '.' . $field;
+            }
 
             return $this->_buildQuery($query, $field, $this->_value($data), $data);
         }

--- a/src/Model/Filter/AbstractFilter.php
+++ b/src/Model/Filter/AbstractFilter.php
@@ -64,8 +64,7 @@ abstract class AbstractFilter
     {
         if ($this->_applicable($data)) {
             $field = $this->config('field');
-            // avoid sql ambiguous field error
-            if (strpos($field, '.') === false) {
+            if (is_string($field) && (strpos($field, '.') === false)) {
                 $field = $query->repository()->alias() . '.' . $field;
             }
 

--- a/tests/TestCase/Model/Filter/LikeFilterTest.php
+++ b/tests/TestCase/Model/Filter/LikeFilterTest.php
@@ -68,7 +68,7 @@ class LikeFilterTest extends TestCase
             $store2 = $d;
         }, ['where']);
 
-        $this->assertEquals($store2->sql($query->valueBinder()), 'name LIKE :c0');
+        $this->assertEquals($store2->sql($query->valueBinder()), 'Articles.name LIKE :c0');
         $this->assertEquals($store2->getValue(), '%test%');
     }
 }

--- a/tests/TestCase/Model/Filter/ValueFilterTest.php
+++ b/tests/TestCase/Model/Filter/ValueFilterTest.php
@@ -82,7 +82,7 @@ class ValueFilterTest extends TestCase
             $store2 = $d;
         }, ['where']);
 
-        $this->assertEquals($store2->sql($query->valueBinder()), 'id = :c0');
+        $this->assertEquals($store2->sql($query->valueBinder()), 'Articles.id = :c0');
         $this->assertEquals($store2->getValue(), 1);
     }
 
@@ -136,7 +136,7 @@ class ValueFilterTest extends TestCase
             $store2 = $d;
         }, ['where']);
 
-        $this->assertEquals($store2->sql($query->valueBinder()), 'id in (:c0,:c1)');
+        $this->assertEquals($store2->sql($query->valueBinder()), 'Articles.id in (:c0,:c1)');
         $this->assertEquals($store2->getValue(), [1, 2]);
     }
 }


### PR DESCRIPTION
Fix error when conditions like this are created:

WHERE code = LIKE :c01

It will trigger an ambiguous field sql errors if the query contain other table with a similar field,
