### PR TITLE
fix filtering empty array/'multiple' parameter

### DIFF
--- a/src/Controller/Component/FilterComponent.php
+++ b/src/Controller/Component/FilterComponent.php
@@ -233,16 +233,17 @@ class FilterComponent extends Component
         $this->controller()->set('searchParameters', $this->parameters());
     }
 }
-//adapted from http://php.net/manual/en/function.array-filter.php#87581
+    /**
+     * Recursively calls array_filter for nested arrays
+     * adapted from http://php.net/manual/en/function.array-filter.php#87581
+     */
 function array_filter_recursive($input, $callback = null)
-  {
-    foreach ($input as &$value)
-    {
-      if (is_array($value))
-      {
-        $value = array_filter_recursive($value, $callback);
-      }
+{
+    foreach ($input as &$value) {
+        if (is_array($value)) {
+            $value = array_filter_recursive($value, $callback);
+        }
     }
 
     return $callback? array_filter($input, $callback) : array_filter($input);
-  }
+}

--- a/src/Controller/Component/FilterComponent.php
+++ b/src/Controller/Component/FilterComponent.php
@@ -213,7 +213,7 @@ class FilterComponent extends Component
         );
 
         if ($this->config('filterEmptyParams')) {
-            $searchParams = array_filter($searchParams);
+            $searchParams = array_filter_recursive($searchParams);
         }
         $params['?'] = $searchParams;
 
@@ -233,3 +233,16 @@ class FilterComponent extends Component
         $this->controller()->set('searchParameters', $this->parameters());
     }
 }
+//adapted from http://php.net/manual/en/function.array-filter.php#87581
+function array_filter_recursive($input, $callback = null)
+  {
+    foreach ($input as &$value)
+    {
+      if (is_array($value))
+      {
+        $value = array_filter_recursive($value, $callback);
+      }
+    }
+
+    return $callback? array_filter($input, $callback) : array_filter($input);
+  }


### PR DESCRIPTION
Bug: 
For "select" forms where multiple options are possible, selecting the empty option populates the query string parameter with an empty value. For normal select forms, the parameter is not populated at all. Because of this, selecting the empty value in a "multiple" form returns no results. 

- The "result" of a multiple select form is an array. therefore, when selecting the empty option, the parameters are as follows: ['multiple_select_form_id'=>[], ...]
- FilterComponent uses 'array_filter' to filter out blank parameters. However, array_filter does not work recursively/on nested arrays.

This simply wraps the call to array_filter in a recursive function found in the [PHP documentation](http://php.net/manual/en/function.array-filter.php#87581). I had to modify it slightly to make the callback work.
